### PR TITLE
refactor(player-info): rename types and restructure context provider

### DIFF
--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -29,7 +29,7 @@ enum Levels {
 
 export type LevelsTypes = `${Levels}`;
 
-export interface ICurrentMode {
+export interface ICurrent {
     modeName: GameModesTypes,
     level: LevelsTypes,
 }
@@ -41,7 +41,9 @@ export interface IFinishedLevel {
     wrongMoves: number,
 }
 
-export type CompletedLevels = {
+
+
+export type CompletedDB = {
   [mode in GameModesTypes]: Partial<Record<LevelsTypes, IFinishedLevel>>
 };
 

--- a/src/providers/player-info/constants.ts
+++ b/src/providers/player-info/constants.ts
@@ -1,0 +1,21 @@
+import { IPlayerInfoContext } from "./playerInfoContext";
+
+export const INITIAL_CONTEXT_STATE: IPlayerInfoContext = {
+    current: {
+        modeName: "education",
+        level: "easy",
+    },
+    finished: {
+        education: {},
+        emotional: {},
+        events: {},
+        states: {},
+    },
+    monster: {
+        unlocked: false,
+        score: 0,
+        wrongMoves: 0,
+        time: 0,
+    }
+
+}

--- a/src/providers/player-info/playerInfoContext.tsx
+++ b/src/providers/player-info/playerInfoContext.tsx
@@ -1,8 +1,13 @@
-import { CompletedLevels, GameModesTypes, IMonster, LevelsTypes } from "@/@types";
+import { CompletedDB,  ICurrent, IMonster } from "@/@types";
+import { createContext } from "react";
+import { INITIAL_CONTEXT_STATE } from "./constants";
 
-interface IPlayerInfoContext {
-    currentMode: GameModesTypes,
-    currentLevel: LevelsTypes,
-    finished: CompletedLevels,
-    monster: IMonster,
+export interface IPlayerInfoContext {
+    current: ICurrent,
+    finished: CompletedDB,
+    monster: IMonster ,
 }
+
+const PlayerInfoContext = createContext<IPlayerInfoContext>(INITIAL_CONTEXT_STATE);
+
+


### PR DESCRIPTION
Rename ICurrentMode to ICurrent and CompletedLevels to CompletedDB for better clarity. Move initial context state to constants file and update context provider implementation.