### PR TITLE
refactor(player-info): change finished type to Map and add format utility

### DIFF
--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -35,7 +35,7 @@ export interface ICurrent {
 }
 
 export interface IFinishedLevel {
-    level: string,
+    level: LevelsTypes,
     score: number,
     time: number,
     wrongMoves: number,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,54 @@
+import { CompletedDB } from './@types';
 import './App.css';
-import Timer from './components/timer/timer';
-import AppRoutes from './routes/AppRoutes';
+import { IPlayerInfoContext } from './providers/player-info/playerInfoContext';
+import { getFinsihedInfo } from './providers/player-info/utils/formatRealtimeDB';
+
+
+const dummy = {
+  current: {
+    modeName: "education",
+    level: "medium"
+  },
+  finished: {
+    education: {
+      easy: {
+        level: "easy",
+        score: 80,
+        time: 12,
+        wrongMoves: 2
+      },
+      medium: {
+        level: "medium",
+        score: 95,
+        time: 18,
+        wrongMoves: 1
+      }
+    },
+    states: {
+      easy: {
+        level: "easy",
+        score: 70,
+        time: 15,
+        wrongMoves: 3
+      }
+    },
+    emotional: {},
+    events: {},
+  },
+  monster: {
+    unlocked: false,
+    score: 0,
+    wrongMoves: 0,
+    time: 0
+  }
+};
+
+const finished: CompletedDB = dummy.finished as CompletedDB;
+const map = getFinsihedInfo(finished);
+
+console.log(map)
+
+
 
 
 
@@ -11,7 +59,7 @@ function App() {
 
        {/* <Timer /> */}
        {/* <SelectMode/> */}
-       <AppRoutes />
+       {/* <AppRoutes /> */}
         
     </>
   )

--- a/src/providers/player-info/playerInfoContext.tsx
+++ b/src/providers/player-info/playerInfoContext.tsx
@@ -1,13 +1,20 @@
-import { CompletedDB,  ICurrent, IMonster } from "@/@types";
+import { CompletedDB,  GameModesTypes,  ICurrent, IFinishedLevel, IMonster } from "@/@types";
 import { createContext } from "react";
 import { INITIAL_CONTEXT_STATE } from "./constants";
 
 export interface IPlayerInfoContext {
     current: ICurrent,
-    finished: CompletedDB,
-    monster: IMonster ,
+    finished: Map<GameModesTypes, IFinishedLevel[]>,
+    monster: IMonster,
 }
 
 const PlayerInfoContext = createContext<IPlayerInfoContext>(INITIAL_CONTEXT_STATE);
 
 
+interface IProvider {
+    children: React.ReactNode;
+}
+
+const PlayerInfoprovider = () => {
+    
+}

--- a/src/providers/player-info/utils/formatRealtimeDB.ts
+++ b/src/providers/player-info/utils/formatRealtimeDB.ts
@@ -1,0 +1,12 @@
+import { CompletedDB, GameModesTypes, IFinishedLevel } from "@/@types";
+
+export const getFinsihedInfo = (finished: CompletedDB): Map<GameModesTypes, IFinishedLevel[]> => {
+    const finsihedMap: Map<GameModesTypes, IFinishedLevel[]> = new Map(); 
+    Object.entries(finished).map((l) => {
+        const mode: GameModesTypes = l[0] as GameModesTypes;
+        const levels = Object.values(l[1]);
+        finsihedMap.set(mode, levels);
+    });
+
+    return finsihedMap;
+}


### PR DESCRIPTION


Convert the finished property in player info context from CompletedDB to Map<GameModesTypes, IFinishedLevel[]> for better data structure Add formatRealtimeDB utility to transform CompletedDB into the new Map format Update IFinishedLevel interface to use LevelsTypes for level field