### PR TITLE
feat(game-state): add RESET_GAME action to reducer

### DIFF
--- a/src/components/game-board/components/game-over/gameOver.tsx
+++ b/src/components/game-board/components/game-over/gameOver.tsx
@@ -2,7 +2,6 @@ import {
     Box, 
     Typography, 
     Paper, 
-    useTheme, 
     Stack, 
     Button, 
     Modal, 
@@ -19,7 +18,6 @@ import {
     Error 
 } from "@mui/icons-material";
 import { useContext, useMemo } from "react";
-import { useNavigate } from "react-router-dom";
 import { GameThemeContext } from "@/providers/theme/themeContext";
 import { GameModesTypes, LevelsTypes } from "@/@types";
 
@@ -31,6 +29,7 @@ interface IProps {
   wrongMoves: number
   level: LevelsTypes
   mode: GameModesTypes
+  onMainMenu: () => void
 }
 
 export default function GameOverModal({
@@ -41,9 +40,9 @@ export default function GameOverModal({
   level,
   mode, 
   onRetry,
+  onMainMenu,
 }: IProps) {
   const {theme} = useContext(GameThemeContext)
-  const navigate = useNavigate();
   const isLight = theme.palette.mode === "light"
 
   const gradient = useMemo(() => (
@@ -54,15 +53,13 @@ export default function GameOverModal({
 
   const backdropGradient = useMemo(() => (isLight ? "rgba(0, 0, 0, 0.4)" : "rgba(0, 0, 0, 0.7)"), [isLight])
 
-  const handleMainMenu = () => {
-    navigate("/memory-game/mode-selection");
-  }
+  
 
 
   return (
     <Modal
       open={open}
-      onClose={handleMainMenu}
+      onClose={onMainMenu}
       closeAfterTransition
       sx={{
         display: "flex",
@@ -116,7 +113,7 @@ export default function GameOverModal({
           }}
         >
           <IconButton
-            onClick={handleMainMenu}
+            onClick={onMainMenu}
             sx={{
               position: "absolute",
               top: 12,
@@ -307,7 +304,7 @@ export default function GameOverModal({
                 variant="outlined"
                 size="medium"
                 startIcon={<Home />}
-                onClick={handleMainMenu}
+                onClick={onMainMenu}
                 sx={{
                   flex: 1,
                   py: 1.5,

--- a/src/components/game-board/gameBoard.tsx
+++ b/src/components/game-board/gameBoard.tsx
@@ -1,6 +1,11 @@
 import { Box, Grid } from "@mui/material";
 import GameCard from "../game-card/gameCard";
-import { useContext, useEffect, useMemo, useState } from "react";
+import { 
+  useContext, 
+  useEffect, 
+  useMemo, 
+  useState 
+} from "react";
 import { getResponsiveColumns } from "./utils/getTheBoardLength";
 import { GameInfoContext } from "@/providers/game-info/gameInfo";
 import GameHeader from "./gameheader";
@@ -11,8 +16,6 @@ import LevelCompleted from "./components/level-completed/levelCompleted";
 import { getAllowedWrongs } from "./components/level-completed/utils/getAllowedWrongs";
 import GameOverModal from "./components/game-over/gameOver";
 
-
-
 const GameBoard = () => {
   const {gameInfo, gameState, gameDispatch }= useContext(GameInfoContext);
   const {playerState ,playerDispatch } = useContext(PlayerInfoContext);
@@ -22,6 +25,10 @@ const GameBoard = () => {
   const handleRetry = () => {
     gameDispatch({type: "RESTART_GAME", payload: gameInfo.level!});
     setGameOver(false);
+  }
+
+  const handleOnMainMenu = () => {
+    gameDispatch({type: "RESET_GAME"});
   }
   useEffect(() => {
     if(gameInfo.level !== playerState.currentInfo.level) {
@@ -55,9 +62,10 @@ const GameBoard = () => {
   },[gameState.openCards]);
   
   useEffect(() => {
-      if(gameState.wrongMoves == allowedWrongs) {
-       setGameOver(true);
-      }
+    if(gameState.wrongMoves == allowedWrongs) {
+      
+      setGameOver(true);
+    }
   }, [gameState.wrongMoves]);
   
     
@@ -68,6 +76,7 @@ const GameBoard = () => {
   if((!gameInfo.level || !gameInfo.mode) && (!playerState.currentInfo.level && !playerState.currentInfo.modeName)) {
     return <SelectionRequired />;
   }
+
   if(gameState.isCompleted && gameInfo.level !== "monster") {
     return <LevelCompleted
       level={ gameInfo.level!}
@@ -79,16 +88,18 @@ const GameBoard = () => {
       isNewRecord= {false}
     />
   }
+
   return (
     <>
       <GameOverModal
         open={gameOver}
-        onRetry={handleRetry}
         level= {gameInfo.level!}
         score={gameState.score}
         timeElapsed={gameState.time}
         mode= {gameInfo.mode!}
         wrongMoves={gameState.wrongMoves}
+        onRetry={handleRetry}
+        onMainMenu={handleOnMainMenu}
       />
       <Box
         sx={{
@@ -97,7 +108,7 @@ const GameBoard = () => {
           justifyContent: "center",
           flexDirection: "column",
           minHeight: "100vh",
-          padding: { xs: 1, sm: 2, md: 3 }, // Responsive padding
+          padding: { xs: 1, sm: 2, md: 3 }, 
           boxSizing: "border-box",
         }}
       >
@@ -107,11 +118,11 @@ const GameBoard = () => {
         <Grid
           container
           spacing={1}
-          columnGap={1} // Responsive spacing
+          columnGap={1} 
           columns={responsiveColumns}
           sx={{
             width: "100%",
-            maxWidth: { xs: "60vw", sm: "60vw", md: "60vw", lg: "600px" }, // Responsive max width
+            maxWidth: { xs: "60vw", sm: "60vw", md: "60vw", lg: "600px" }, 
           }}
         >
           {gameState.cards.map((value, index) => (
@@ -122,7 +133,7 @@ const GameBoard = () => {
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "center",
-                aspectRatio: "1", // Keep cards square
+                aspectRatio: "1", 
               }}
             >
               <GameCard

--- a/src/components/timer/timer.tsx
+++ b/src/components/timer/timer.tsx
@@ -14,6 +14,8 @@ import {
 const GameTimer = () => {
     const {gameState, gameDispatch} = useContext(GameInfoContext);
     const timerRef = useRef<NodeJS.Timeout | null>(null);
+
+
     useEffect(() => {
         
         if (!gameState.initialized) {

--- a/src/reducers/game-state/reducer.tsx
+++ b/src/reducers/game-state/reducer.tsx
@@ -17,7 +17,8 @@ export type Action =
     {type: "FLIPP_CARD", payload: number} |
     {type: "CHECK_MATCHED"} |
     {type: "RESTART_GAME", payload: LevelsTypes} |
-    {type: "HANDLE_TIME", payload: number}  
+    {type: "HANDLE_TIME", payload: number}  |
+    {type: "RESET_GAME"}
 
 export const reducer = (state: IState, action: Action) : IState=> {
     switch(action.type) {
@@ -123,6 +124,20 @@ export const reducer = (state: IState, action: Action) : IState=> {
             return {
                 ...state,
                 cards,
+                wrongMoves: 0,
+                time: 0,
+                score: 0,
+                isGameActive: false,
+                isCompleted: false,
+                openCards: [],
+                initialized: true,
+            }
+        }
+
+        case "RESET_GAME": {
+            return {
+                ...state,
+                cards: [],
                 wrongMoves: 0,
                 time: 0,
                 score: 0,


### PR DESCRIPTION
Implement RESET_GAME action to fully reset game state when returning to main menu. This ensures clean state transitions and prevents residual data from previous games.

Also removed unused imports and cleaned up whitespace in timer component.MG