### PR TITLE
feat(select-game): add level stats overlay for completed levels

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import './App.css';
+import MemoryCardWithOverlay from './components/select-game/components/levelInfo';
 import AppRoutes from './routes/AppRoutes';
 
 
@@ -18,7 +19,7 @@ function App() {
     // <MemoryGameDashboard />
     // <SignInPage />
     <AppRoutes />
-    
+
     // <MonsterLevelCard />
     // <LevelCompleted />
     // <GameLoader />

--- a/src/components/dashboard/components/modeCard.tsx
+++ b/src/components/dashboard/components/modeCard.tsx
@@ -15,7 +15,7 @@ import { ICompletedMode } from '../types'
 import { GameThemeContext } from '@/providers/theme/themeContext'
 import { getModeIcon } from '../utils/getModeIcon'
 interface IProps {
-    modeData: ICompletedMode
+    modeData: ICompletedMode;
 }
 const ModeCard = ({modeData}: IProps) => {
     const {mode, theme} = useContext(GameThemeContext);
@@ -23,24 +23,24 @@ const ModeCard = ({modeData}: IProps) => {
     const modeIcon = getModeIcon(modeData.mode);
     return (
         <Paper
-                key={modeData.mode}
-                elevation={0}
-                sx={{
-                    p: 3,
-                    borderRadius: 2,
-                    backgroundImage:
-                    mode === "light"
-                        ? "linear-gradient(135deg, rgba(76, 175, 80, 0.08) 0%, rgba(255, 255, 255, 0.9) 50%, rgba(76, 175, 80, 0.05) 100%)"
-                        : "linear-gradient(135deg, rgba(76, 175, 80, 0.15) 0%, rgba(45, 27, 78, 0.9) 50%, rgba(76, 175, 80, 0.1) 100%)",
-                    backdropFilter: "blur(15px)",
-                    WebkitBackdropFilter: "blur(15px)",
-                    border: `1px solid ${modeColor}30`,
-                    boxShadow: mode === "light" ? `0 4px 16px ${modeColor}10` : `0 4px 16px rgba(0, 0, 0, 0.3)`,
-                    transition: "all 0.3s cubic-bezier(0.4, 0, 0.2, 1)",
-                    "&:hover": {
-                    transform: "translateY(-2px)",
-                    boxShadow: mode === "light" ? `0 8px 25px ${modeColor}20` : `0 8px 25px rgba(0, 0, 0, 0.4)`,
-                    },
+            key={modeData.mode}
+            elevation={0}
+            sx={{
+                p: 3,
+                borderRadius: 2,
+                backgroundImage:
+                mode === "light"
+                    ? "linear-gradient(135deg, rgba(76, 175, 80, 0.08) 0%, rgba(255, 255, 255, 0.9) 50%, rgba(76, 175, 80, 0.05) 100%)"
+                    : "linear-gradient(135deg, rgba(76, 175, 80, 0.15) 0%, rgba(45, 27, 78, 0.9) 50%, rgba(76, 175, 80, 0.1) 100%)",
+                backdropFilter: "blur(15px)",
+                WebkitBackdropFilter: "blur(15px)",
+                border: `1px solid ${modeColor}30`,
+                boxShadow: mode === "light" ? `0 4px 16px ${modeColor}10` : `0 4px 16px rgba(0, 0, 0, 0.3)`,
+                transition: "all 0.3s cubic-bezier(0.4, 0, 0.2, 1)",
+                "&:hover": {
+                transform: "translateY(-2px)",
+                boxShadow: mode === "light" ? `0 8px 25px ${modeColor}20` : `0 8px 25px rgba(0, 0, 0, 0.4)`,
+                },
                 }}
                 >
                 <Stack direction="row" justifyContent="space-between" alignItems="center" mb={2}>

--- a/src/components/select-game/components/cardStatesOverlay.tsx
+++ b/src/components/select-game/components/cardStatesOverlay.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import type React from "react";
+import { Box, Typography, Stack, Chip } from "@mui/material";
+import { Timer, Error, Star, EmojiEvents } from "@mui/icons-material";
+import { useContext } from "react";
+import { GameThemeContext } from "@/providers/theme/themeContext";
+
+interface CardStatsOverlayProps {
+  wrongMoves: number;
+  time: string;
+  score: number;
+  stars: number;
+  visible: boolean;
+  position?: {
+    top?: number;
+    left?: number;
+    right?: number;
+    bottom?: number;
+  };
+  isMonsterLevel?: boolean;
+}
+
+export default function CardStatsOverlay({
+  wrongMoves,
+  time,
+  score,
+  stars,
+  visible,
+  position = { top: 0, left: 0 },
+  isMonsterLevel = false,
+}: CardStatsOverlayProps) {
+  const { theme, mode } = useContext(GameThemeContext);
+
+  const monsterColor = "#FF4500";
+  const glowColor = "rgba(255, 69, 0, 0.6)";
+
+  const overlayGradient = isMonsterLevel
+    ? mode === "light"
+      ? "linear-gradient(135deg, rgba(255, 255, 255, 0.85) 0%, rgba(255, 240, 230, 0.90) 25%, rgba(255, 69, 0, 0.15) 50%, rgba(220, 20, 60, 0.10) 75%, rgba(255, 255, 255, 0.85) 100%)"
+      : "linear-gradient(135deg, rgba(139, 69, 19, 0.90) 0%, rgba(255, 140, 0, 0.85) 25%, rgba(255, 69, 0, 0.88) 50%, rgba(220, 20, 60, 0.90) 75%, rgba(139, 69, 19, 0.95) 100%)"
+    : mode === "light"
+    ? "linear-gradient(135deg, rgba(255, 255, 255, 0.85) 0%, rgba(255, 255, 255, 0.75) 25%, rgba(248, 250, 252, 0.80) 50%, rgba(241, 245, 249, 0.70) 75%, rgba(255, 255, 255, 0.85) 100%)"
+    : "linear-gradient(135deg, rgba(45, 27, 78, 0.90) 0%, rgba(35, 20, 60, 0.85) 25%, rgba(25, 15, 45, 0.90) 50%, rgba(30, 18, 55, 0.80) 75%, rgba(45, 27, 78, 0.90) 100%)";
+
+  const getScoreColor = () => {
+    if (wrongMoves === 0) return theme.palette.success.main;
+    if (wrongMoves <= 3) return theme.palette.warning.main;
+    return theme.palette.error.main;
+  };
+
+  const getStarsColor = () => {
+    if (stars >= 3) return "#FFD700";
+    if (stars >= 2) return theme.palette.warning.main;
+    return theme.palette.grey[400];
+  };
+
+  const StatItem = ({
+    icon,
+    label,
+    value,
+    color,
+  }: {
+    icon: React.ReactNode;
+    label: string;
+    value: string | number;
+    color: string;
+  }) => (
+    <Stack direction="row" spacing={1} alignItems="center" sx={{ minWidth: 0 }}>
+      <Box
+        sx={{
+          width: 24,
+          height: 24,
+          borderRadius: "50%",
+          backgroundColor: `${color}20`,
+          border: `1px solid ${color}40`,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: color,
+          flexShrink: 0,
+        }}
+      >
+        {icon}
+      </Box>
+      <Box sx={{ minWidth: 0, flex: 1 }}>
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{
+            fontSize: "0.7rem",
+            fontWeight: 500,
+            textTransform: "uppercase",
+            letterSpacing: 0.5,
+          }}
+        >
+          {label}
+        </Typography>
+        <Typography
+          variant="body2"
+          fontWeight={600}
+          sx={{
+            color: color,
+            fontSize: "0.85rem",
+            textShadow: isMonsterLevel ? "0 1px 2px rgba(0,0,0,0.3)" : "none",
+          }}
+        >
+          {value}
+        </Typography>
+      </Box>
+    </Stack>
+  );
+
+  if (!visible) return null;
+
+  return (
+    <Box
+      sx={{
+        position: "absolute",
+        ...position,
+        zIndex: 1000,
+        width: "200px",
+        backgroundImage: overlayGradient,
+        backdropFilter: "blur(20px)",
+        WebkitBackdropFilter: "blur(20px)",
+        border: isMonsterLevel ? `2px solid ${monsterColor}60` : `1px solid ${theme.palette.primary.main}30`,
+        borderRadius: 3,
+        p: 2,
+        boxShadow: isMonsterLevel
+          ? `0 0 20px ${glowColor}, 0 8px 32px rgba(0, 0, 0, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.2)`
+          : mode === "light"
+          ? `0 8px 32px ${theme.palette.primary.main}15, inset 0 1px 0 rgba(255, 255, 255, 0.4)`
+          : `0 8px 32px rgba(0, 0, 0, 0.6), inset 0 1px 0 rgba(255, 255, 255, 0.1)`,
+        opacity: visible ? 1 : 0,
+        transform: visible ? "translateY(0) scale(1)" : "translateY(-10px) scale(0.95)",
+        transition: "all 0.3s cubic-bezier(0.4, 0, 0.2, 1)",
+        pointerEvents: "none",
+        ...(isMonsterLevel && {
+          animation: "monsterOverlayGlow 2s ease-in-out infinite alternate",
+          "@keyframes monsterOverlayGlow": {
+            "0%": {
+              boxShadow: `0 0 20px ${glowColor}, 0 8px 32px rgba(0, 0, 0, 0.4)`,
+            },
+            "100%": {
+              boxShadow: `0 0 30px ${glowColor}, 0 12px 40px rgba(0, 0, 0, 0.6)`,
+            },
+          },
+        }),
+      }}
+    >
+      {isMonsterLevel && (
+        <>
+          <Box
+            sx={{
+              position: "absolute",
+              top: -5,
+              right: 10,
+              width: "12px",
+              height: "16px",
+              background: "linear-gradient(45deg, #FF4500, #FFD700, #FF6347)",
+              borderRadius: "50% 50% 50% 50% / 60% 60% 40% 40%",
+              opacity: 0.7,
+              filter: "blur(1px)",
+              animation: "flicker 2s ease-in-out infinite alternate",
+              "@keyframes flicker": {
+                "0%": { opacity: 0.5, transform: "scale(1) rotate(-2deg)" },
+                "50%": { opacity: 0.9, transform: "scale(1.1) rotate(1deg)" },
+                "100%": { opacity: 0.7, transform: "scale(1.05) rotate(-1deg)" },
+              },
+            }}
+          />
+          <Box
+            sx={{
+              position: "absolute",
+              bottom: -3,
+              left: 15,
+              width: "10px",
+              height: "14px",
+              background: "linear-gradient(45deg, #FF6347, #FF4500, #FFD700)",
+              borderRadius: "50% 50% 50% 50% / 60% 60% 40% 40%",
+              opacity: 0.6,
+              filter: "blur(1px)",
+              animation: "flicker 1.8s ease-in-out infinite alternate-reverse",
+            }}
+          />
+        </>
+      )}
+
+      <Stack spacing={1.5}>
+        <Box textAlign="center">
+          <Typography
+            variant="body2"
+            fontWeight={700}
+            sx={{
+              color: isMonsterLevel ? monsterColor : theme.palette.primary.main,
+              fontSize: "0.8rem",
+              textTransform: "uppercase",
+              letterSpacing: 1,
+              textShadow: isMonsterLevel ? "0 1px 2px rgba(0,0,0,0.3)" : "none",
+              ...(isMonsterLevel && {
+                background: `linear-gradient(135deg, ${monsterColor}, #FFD700)`,
+                backgroundClip: "text",
+                WebkitBackgroundClip: "text",
+                WebkitTextFillColor: "transparent",
+              }),
+            }}
+          >
+            {isMonsterLevel ? "Monster Stats" : "Game Stats"}
+          </Typography>
+        </Box>
+
+        <Stack spacing={1}>
+          <StatItem
+            icon={<Error sx={{ fontSize: 14 }} />}
+            label="Wrong"
+            value={wrongMoves}
+            color={theme.palette.error.main}
+          />
+          <StatItem icon={<Timer sx={{ fontSize: 14 }} />} label="Time" value={time} color={theme.palette.info.main} />
+          <StatItem
+            icon={<EmojiEvents sx={{ fontSize: 14 }} />}
+            label="Score"
+            value={score}
+            color={getScoreColor()}
+          />
+          <StatItem icon={<Star sx={{ fontSize: 14 }} />} label="Stars" value={`${stars}/3`} color={getStarsColor()} />
+        </Stack>
+
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "center",
+            gap: 0.5,
+            mt: 1,
+            p: 1,
+            borderRadius: 2,
+            backgroundColor: isMonsterLevel
+              ? `${monsterColor}10`
+              : mode === "light"
+              ? "rgba(255, 255, 255, 0.5)"
+              : "rgba(0, 0, 0, 0.3)",
+            border: `1px solid ${isMonsterLevel ? monsterColor : theme.palette.primary.main}20`,
+          }}
+        >
+          {Array.from({ length: 3 }, (_, i) => (
+            <Star
+              key={i}
+              sx={{
+                fontSize: 16,
+                color: i < stars ? "#FFD700" : theme.palette.grey[400],
+                filter: i < stars ? "drop-shadow(0 0 4px #FFD700)" : "none",
+                transition: "all 0.3s ease",
+                ...(isMonsterLevel &&
+                  i < stars && {
+                    animation: `starTwinkle ${1 + i * 0.2}s ease-in-out infinite alternate`,
+                    "@keyframes starTwinkle": {
+                      "0%": { opacity: 0.8, transform: "scale(1)" },
+                      "100%": { opacity: 1, transform: "scale(1.1)" },
+                    },
+                  }),
+              }}
+            />
+          ))}
+        </Box>
+
+        <Box textAlign="center">
+          <Chip
+            label={
+              wrongMoves === 0 ? "Perfect!" : wrongMoves <= 3 ? "Great!" : wrongMoves <= 6 ? "Good" : "Keep Trying!"
+            }
+            size="small"
+            sx={{
+              fontSize: "0.7rem",
+              height: 20,
+              backgroundColor: getScoreColor() + "20",
+              color: getScoreColor(),
+              border: `1px solid ${getScoreColor()}40`,
+              fontWeight: 600,
+              ...(isMonsterLevel && {
+                background: `linear-gradient(135deg, ${monsterColor}30, #FFD70030)`,
+                border: `1px solid ${monsterColor}60`,
+                color: isMonsterLevel ? monsterColor : getScoreColor(),
+              }),
+            }}
+          />
+        </Box>
+      </Stack>
+    </Box>
+  );
+}

--- a/src/components/select-game/components/levelCard.tsx
+++ b/src/components/select-game/components/levelCard.tsx
@@ -4,6 +4,9 @@ import { GameThemeContext } from "@/providers/theme/themeContext";
 import { useContext, useMemo } from "react";
 import { Box, Chip, Typography } from "@mui/material";
 import { CheckCircle, Lock } from "@mui/icons-material";
+import { getLevelDetails } from "../utils/getLevelDetails";
+import { PlayerInfoContext } from "@/providers/player-info/playerInfoContext";
+import MemoryCardWithOverlay from "./levelInfo";
 
 export interface IProps {
     level: IGameLevel;
@@ -21,16 +24,30 @@ const LevelCard = ({
         handleLevelSelect,
     }: IProps) => {
     const {mode, theme} = useContext(GameThemeContext);
-    const isUnlocked = selectedMode ? isLevelUnlocked(selectedMode, level.id) : false
-    const isCompleted = selectedMode ? isLevelCompleted(selectedMode, level.id) : false
+    const {playerState} = useContext(PlayerInfoContext);
+    const isUnlocked = selectedMode ? isLevelUnlocked(selectedMode, level.id) : false;
+    const isCompleted = selectedMode ? isLevelCompleted(selectedMode, level.id) : false;
       const cardGradient = useMemo(() => (
       mode === "light"
         ? "linear-gradient(135deg, rgba(255, 255, 255, 0.95) 0%, rgba(255, 255, 255, 0.85) 25%, rgba(248, 250, 252, 0.90) 50%, rgba(241, 245, 249, 0.80) 75%, rgba(255, 255, 255, 0.95) 100%)"
         : "linear-gradient(135deg, rgba(45, 27, 78, 0.95) 0%, rgba(35, 20, 60, 0.90) 25%, rgba(25, 15, 45, 0.95) 50%, rgba(30, 18, 55, 0.85) 75%, rgba(45, 27, 78, 0.95) 100%)"
 
   ), [mode]);
-    return (
-      <Box
+
+    const details = useMemo(() => {
+      if(isCompleted) {
+        const finished = playerState.finished.get(selectedMode);
+        const levelDetails = getLevelDetails(level.id, finished!);
+        return levelDetails;
+      }
+      else {
+        return null;
+      }
+    }, [isCompleted]);
+
+      
+     const Notoverlayed = 
+     <Box
         onClick={() => isUnlocked && handleLevelSelect(level.id)}
         sx={{
           position: "relative",
@@ -93,7 +110,17 @@ const LevelCard = ({
           </Typography>
         </Box>
       </Box>
-    )
+      if(isCompleted) {
+        
+        return (
+          <MemoryCardWithOverlay {...details!}>
+            {Notoverlayed}
+          </MemoryCardWithOverlay>
+        )
+      }
+      else {
+        return (Notoverlayed);
+      }
 }
 
 export default LevelCard;

--- a/src/components/select-game/components/levelInfo.tsx
+++ b/src/components/select-game/components/levelInfo.tsx
@@ -1,0 +1,106 @@
+
+
+import type React from "react";
+import { Box } from "@mui/material";
+import { useState } from "react";
+import CardStatsOverlay from "./cardStatesOverlay";
+
+interface IProps {
+  time: number;
+  score: number;
+  starsNumber: number;
+  wrongMoves: number;
+  children: React.ReactNode;
+  disabled?: boolean;
+}
+
+export default function MemoryCardWithOverlay({
+  time,
+  score,
+  starsNumber,
+  wrongMoves,
+  children,
+  disabled = false,
+}: IProps) {
+  const [showOverlay, setShowOverlay] = useState(true);
+  const [overlayPosition, setOverlayPosition] = useState({ top: 0, left: 0 });
+
+  const handleMouseEnter = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (disabled) return;
+
+    const rect = event.currentTarget.getBoundingClientRect();
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+
+    let left = rect.left + rect.width + 10;
+    let top = rect.top;
+
+    if (left + 200 > viewportWidth) {
+      left = rect.left - 210;
+    }
+
+    if (top + 200 > viewportHeight) {
+      top = viewportHeight - 220;
+    }
+
+    setOverlayPosition({ top, left });
+    setShowOverlay(true);
+  };
+
+  const handleMouseLeave = () => {
+    setShowOverlay(false);
+  };
+
+  const formatTime = (seconds: number) => {
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `${mins.toString().padStart(2, "0")}:${secs
+      .toString()
+      .padStart(2, "0")}`;
+  };
+
+  return (
+    <>
+      <Box
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        sx={{
+          position: "relative",
+          cursor: disabled ? "not-allowed" : "pointer",
+          transition: "all 0.3s ease",
+          "&:hover": !disabled
+            ? {
+                transform: "translateY(-2px)",
+                filter: "brightness(1.1)",
+              }
+            : {},
+        }}
+      >
+        {children}
+      </Box>
+
+      <Box
+        sx={{
+          position: "fixed",
+          top: 0,
+          left: 0,
+          pointerEvents: "none",
+          zIndex: 9999,
+        }}
+      >
+        <CardStatsOverlay
+          wrongMoves={wrongMoves}
+          time={formatTime(time)}
+          score={score}
+          stars={starsNumber}
+          visible={showOverlay}
+          position={{
+            top: overlayPosition.top,
+            left: overlayPosition.left,
+          }}
+          isMonsterLevel={false} 
+        />
+      </Box>
+    </>
+  );
+}

--- a/src/components/select-game/utils/getLevelDetails.ts
+++ b/src/components/select-game/utils/getLevelDetails.ts
@@ -1,0 +1,25 @@
+import { IFinishedLevel, LevelsTypes } from "@/@types";
+import { getAllowedWrongs } from "@/components/game-board/components/level-completed/utils/getAllowedWrongs";
+
+export const getLevelDetails = (level: LevelsTypes, finished: IFinishedLevel[]) => {
+    const selectedLevel = finished.find((f) => (level === f.level));
+    
+        const details = {
+            time: selectedLevel!.time,
+            wrongMoves: selectedLevel!.wrongMoves,
+            score: selectedLevel!.score,
+            starsNumber: getStarsByWrongMoves(level ,selectedLevel!.wrongMoves),
+        }
+        return details;
+    
+}
+export const getWrongMovesPerStar = (level: LevelsTypes): number => {
+  const allowedWrongs = getAllowedWrongs(level);
+  return Math.ceil(allowedWrongs / 3);
+}
+
+export const getStarsByWrongMoves = (level: LevelsTypes, wrongMoves: number): number => {
+  const perStar = getWrongMovesPerStar(level);
+  const lostStars = Math.floor(wrongMoves / perStar);
+  return Math.max(3 - lostStars, 0);
+}


### PR DESCRIPTION
Implement hoverable overlay showing time, score, wrong moves and stars for completed levels Add utility functions to calculate stars based on wrong moves Create reusable overlay components with animations and responsive positioning