### PR TITLE
feat(dashboard): improve dashboard UI and logic

### DIFF
--- a/src/components/dashboard/components/completedList.tsx
+++ b/src/components/dashboard/components/completedList.tsx
@@ -1,19 +1,59 @@
-import Stack from '@mui/material/Stack'
-import { ICompletedMode } from '../types'
-import ModeCard from './modeCard'
+import Stack from '@mui/material/Stack';
+import { ICompletedMode } from '../types';
+import ModeCard from './modeCard';
+import Box from '@mui/material/Box';
+import SentimentDissatisfiedIcon from '@mui/icons-material/SentimentDissatisfied';
+import Typography from '@mui/material/Typography';
+import { useContext } from 'react';
+import { GameThemeContext } from '@/providers/theme/themeContext';
 interface IProps {
     completedModes: ICompletedMode[]
 }
 const CompletedList = ({completedModes}: IProps) => {
+    const {theme} = useContext(GameThemeContext);
     return (
         <Stack spacing={2}>
             {
-                completedModes.map((completed) => (
-                    <ModeCard
-                        key={completed.mode}
-                        modeData={completed}
-                    />
-                ))
+                completedModes.length == 0 
+                ? (
+                    <Box
+                        sx={{
+                            textAlign: 'center',
+                            py: 4,
+                            px: 2,
+                            borderRadius: 4,
+                            backgroundColor:
+                            theme.palette.mode === 'light'
+                                ? 'rgba(0,0,0,0.04)'
+                                : 'rgba(255,255,255,0.02)',
+                            border: `1px dashed ${theme.palette.divider}`,
+                        }}
+                        >
+                        <SentimentDissatisfiedIcon
+                            sx={{
+                            fontSize: 50,
+                            mb: 1,
+                            color: theme.palette.text.secondary,
+                            }}
+                        />
+                        <Typography
+                            variant="h6"
+                            fontWeight={500}
+                            color="text.secondary"
+                        >
+                            You haven’t completed any level yet!
+                        </Typography>
+                    </Box>
+                )
+                : (
+                    completedModes.map((completed) => (
+                        <ModeCard
+                            key={completed.mode}
+                            modeData={completed}
+                        />
+                    ))
+
+                )
             }
         </Stack>
     )

--- a/src/components/dashboard/hook/useDashboard.ts
+++ b/src/components/dashboard/hook/useDashboard.ts
@@ -33,7 +33,7 @@ export const useDashboard = () => {
   const progress = useMemo(() => getLevelPercentage(playerState.currentInfo.level), [playerState]);
   const navigate = useNavigate();
   const initials = useMemo(() => getInitials(user), [user]);
-  
+  console.log(playerState)
   const handleNavigate = (page: "/" | "/memory-game/mode-selection") => {
     navigate(page);
   }

--- a/src/components/dashboard/playerDashboard.tsx
+++ b/src/components/dashboard/playerDashboard.tsx
@@ -211,7 +211,7 @@ export default function MemoryGameDashboard() {
 
           <Stack spacing={2}>
             <Typography variant="h6" fontWeight={600}>
-              Completed Game Modes
+              Modes progress
             </Typography>
             <CompletedList completedModes={completedModes}/>
           </Stack>

--- a/src/components/dashboard/utils/getDiplayLevel.ts
+++ b/src/components/dashboard/utils/getDiplayLevel.ts
@@ -6,6 +6,7 @@ export const getFormatedlevel = (level: LevelsTypes) => {
 
 export const getLevelPercentage = (level: LevelsTypes) => {
     const levels: LevelsTypes[] = Object.values(Levels);
-    const percentage = (((levels.indexOf(level) + 1) / levels.length) * 100);
+    const number = level === "easy" ? levels.indexOf(level)  : levels.indexOf(level) + 1;
+    const percentage = (((number) / levels.length) * 100);
     return percentage;
 } 

--- a/src/components/dashboard/utils/getFinished.ts
+++ b/src/components/dashboard/utils/getFinished.ts
@@ -22,6 +22,7 @@ export const getFinishedNumber = (finished: Map<GameModesTypes, IFinishedLevel[]
 
 export const getFinishedLevelsNumber = (finished: Map<GameModesTypes, IFinishedLevel[]>) => {
     const finishedLevels = [...finished.values()];
-    const number = finishedLevels.length;
+    const number = finishedLevels.reduce((curr, acc) => curr + acc.length, 0)
+
     return number;
 }

--- a/src/components/dashboard/utils/getModeDetails.ts
+++ b/src/components/dashboard/utils/getModeDetails.ts
@@ -5,7 +5,9 @@ import { Theme } from "@mui/material";
 export const getModeDetails = (finished: Map<GameModesTypes, IFinishedLevel[]>) => {
     const completedDetails: ICompletedMode[] = [];
     for(const [key, value] of finished.entries()) {
-        
+            if(getTotalScore(value) == 0) {
+                continue;
+            }
             const completed: ICompletedMode = {
                 mode: key,
                 totalScore: getTotalScore(value),

--- a/src/components/game-board/gameBoard.tsx
+++ b/src/components/game-board/gameBoard.tsx
@@ -16,6 +16,7 @@ import { getAllowedWrongs } from "./components/level-completed/utils/getAllowedW
 import GameOverModal from "./components/game-over/gameOver";
 import { getCardImage } from "../game-card/service/getImage.service";
 import GameLoader from "../loader/loader";
+import { getTheNextlevel } from "./utils/getTheNextLevel";
 
 
 const GameBoard = () => {
@@ -46,6 +47,10 @@ const GameBoard = () => {
             time: gameState.time,
             wrongMoves: gameState.wrongMoves,
           } 
+          const next = getTheNextlevel(gameInfo.level!);
+          if(next) {
+            playerDispatch({type: "CHANGE_CURRENT", payload: {level: next, modeName: gameInfo.mode!}})
+          }
           playerDispatch({type: "ADD_FINISHED", payload:{mode: gameInfo.mode!, level: finishedLevel}});
       }  
   }, [gameState.isCompleted]);

--- a/src/providers/game-info/gameInfo.tsx
+++ b/src/providers/game-info/gameInfo.tsx
@@ -1,9 +1,9 @@
 import { GameModesTypes, LevelsTypes } from "@/@types";
-import { createContext, useContext, useEffect, useReducer, useState } from "react";
+import { createContext, useReducer, useState } from "react";
 import { initialContext, initialGame } from "./constants";
 import { Action, IState, reducer } from "@/reducers/game-state/reducer";
 import { INITIAL_STATE } from "@/reducers/game-state/constants";
-import { PlayerInfoContext } from "../player-info/playerInfoContext";
+
 
 export interface IGameInfo {
     mode: GameModesTypes | null;
@@ -27,12 +27,8 @@ export const GameInfoContext = createContext<IGameInfoContext>(initialContext);
 export const GameProvider = (props: IProps) => {
     const [gameInfo, setGameInfo] = useState<IGameInfo>(initialGame);
     const [gameState, gameDispatch] = useReducer(reducer, INITIAL_STATE);
-    const {playerState} = useContext(PlayerInfoContext);
-    useEffect(() => {
-        if(playerState.currentInfo.level && playerState.currentInfo.modeName) {
-            setGameInfo({mode: playerState.currentInfo.modeName, level: playerState.currentInfo.level});
-        }
-    }, [playerState])
+    
+
     
 
     const changeMode = (mode: GameModesTypes) => {


### PR DESCRIPTION
- Update section title from "Completed Game Modes" to "Modes progress"
- Add empty state UI for completed modes list
- Fix level percentage calculation logic
- Remove unused useEffect in game provider
- Add next level progression after game completion
- Skip zero-score modes in dashboard display
- Add debug log for player state