### PR TITLE
feat(game-board): add initial card reveal feature with timed hide

### DIFF
--- a/src/components/game-board/utils/getShowTime.ts
+++ b/src/components/game-board/utils/getShowTime.ts
@@ -1,0 +1,4 @@
+export const getShowTime = (totalCards: number) => {
+    const showTime = Math.min(8000, Math.max(2000, totalCards * 250));
+    return showTime;
+}

--- a/src/components/game-card/hook/useGameBoard.tsx
+++ b/src/components/game-card/hook/useGameBoard.tsx
@@ -12,10 +12,13 @@ const useGameBoard = ({isMatched, isFlipped, id}: IProps) => {
   const [isHovered, setIsHovered] = useState(false);
   const theme = useTheme();
   const { gameDispatch, gameState } = useContext(GameInfoContext);
-
+  const isAllFlipped = useMemo(() => {
+    const allFlipped = gameState.cards.every((c) => c.isFlipped);
+    return allFlipped;
+  }, [gameState.cards])
 
   const handleFlipped = useCallback(() => {
-    if (isMatched || gameState.openCards.length === 2) return;
+    if (isMatched || gameState.openCards.length === 2 || isAllFlipped) return;
 
     gameDispatch({ type: "FLIPP_CARD", payload: id });
   }, [isMatched, gameDispatch, id, gameState.openCards.length]);

--- a/src/reducers/game-state/reducer.tsx
+++ b/src/reducers/game-state/reducer.tsx
@@ -20,11 +20,14 @@ export type Action =
     {type: "RESTART_GAME", payload: {level: LevelsTypes, mode: GameModesTypes | null}} |
     {type: "HANDLE_TIME", payload: number}  |
     {type: "RESET_GAME"} |
-    {type: "GAME_OVER"} 
+    {type: "GAME_OVER"} |
+    {type: "SHOW_ALL"} |
+    {type: "HIDE_ALL"} 
 
 export const reducer = (state: IState, action: Action) : IState=> {
     switch(action.type) {
         case "INITIAL_GAME": {
+                
                 const cards = getGameCards(action.payload.level, action.payload.mode);
                 return {
                     ...state,
@@ -166,6 +169,21 @@ export const reducer = (state: IState, action: Action) : IState=> {
                 isGameActive: false,
                 isOver: true,
 
+            }
+        }
+
+        case "SHOW_ALL": {
+            const newCards = state.cards.map((c) => ({...c, isFlipped: true}))
+            return {
+                ...state,
+                cards: newCards
+            }
+        }
+        case "HIDE_ALL": {
+            const newCards = state.cards.map((c) => ({...c, isFlipped: false}))
+            return {
+                ...state,
+                cards: newCards
             }
         }
     }


### PR DESCRIPTION
Add functionality to show all cards briefly at game start to help players memorize positions. Cards are automatically hidden after a calculated duration based on deck size. Includes new utility function for calculating show time and reducer actions for mass card flipping.